### PR TITLE
Updated ne_download for rasters

### DIFF
--- a/R/ne_download.r
+++ b/R/ne_download.r
@@ -117,7 +117,7 @@ ne_download <- function(scale = 110,
   if ( load & category == 'raster' )
   {
     # have to use file_name to set the folder and the tif name
-    rst <- raster::raster(file.path(destdir, file_name, paste0(file_name, '.tif')))
+    rst <- raster::raster(file.path(destdir, paste0(file_name, '.tif')))
     return(rst)
     
     


### PR DESCRIPTION
The previous version downloaded properly, but added an extra filename in the path. This appears to work now.